### PR TITLE
Add --tunnel option to deploy ssh.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add --tunnel option to deploy ssh. [jone]
 
 
 1.1.0 (2018-12-21)

--- a/ftw/deploy/tests/test_command_ssh.py
+++ b/ftw/deploy/tests/test_command_ssh.py
@@ -54,3 +54,30 @@ class TestCommandSSH(TestCase):
         assert ret.stderr == ''
         cmd = r'ssh -L 10101:localhost:10101 example.com -t cd /apps/02-test; bash --login'
         assert [cmd] == self.get_executed_commands()
+
+    def test_ssh_with_tunnel_option(self):
+        ret = self.deploy('ssh', '--tunnel', 'test')
+        assert ret.stderr == ''
+
+        ports_to_tunnel = (
+            10200,  # instance0
+            10201,  # instance1
+            10202,  # instance2
+            10203,  # instance3
+            10204,  # instance4
+            10210,  # instancepub
+            10230,  # solr
+            10250,  # haproxy
+        )
+
+        cmd = r'ssh {} example.com -t cd /apps/02-test; bash --login'.format(
+            ' '.join(['-L {0}:localhost:{0}'.format(port) for port in ports_to_tunnel])
+        )
+        self.maxDiff = None
+        assert [cmd] == self.get_executed_commands()
+
+    def test_ssh_with_tunnel_option_failes_wihtout_deployment_number(self):
+        ret = self.deploy('ssh', '--tunnel', 'origin')
+        assert not ret.success
+        assert ret.stdout == ''
+        assert 'ERROR: Could not find deployment number of remote.\n' == ret.stderr


### PR DESCRIPTION
The --tunnel option automatically adds a bunch of port forwardings with the standard port schema of our company.